### PR TITLE
Fix theme search functionality

### DIFF
--- a/hbp_sphinx_theme/layout.html
+++ b/hbp_sphinx_theme/layout.html
@@ -7,6 +7,11 @@
 
 {% block extrahead %}
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+    .search .context {
+        display: none;
+    }
+</style>
 {% endblock %}
 
 {% block relbar1 %}
@@ -53,7 +58,7 @@
                     {% endif %}
                 </aside>
 
-                {{ body }}
+                {% block body %} {% endblock %}
             </div>
 
             <aside class="hbpdoc-hnav hbpdoc-hnav-bottom">


### PR DESCRIPTION
In the HBP neurorobotics platform we are using the sphinx "Quick search" functionality.

This functionality however is broken in the hbp_sphinx_theme as you can observe the in publicly available documentation [HBP Neurorobotics Platform](https://developer.humanbrainproject.eu/docs/projects/HBP%20Neurorobotics%20Platform/1.2/index.html#hbp-neurorobotics-guide-book).

Our user have reported this [issue](https://bitbucket.org/hbpneurorobotics/neurorobotics-platform/issues/68/quick-search-is-not-working) to us and we would like to fix it. 
This pull request fixes the bug. The documentation generated with this fix has the "Quick search" functionality working as it can be observed in the [website](http://fix-hbp-sphinx-bbp-ou-neurorobotics.apps.bbp.epfl.ch/) that we have put online to demo the fix.

